### PR TITLE
feat: log information about wpa-supplicant

### DIFF
--- a/bin/report
+++ b/bin/report
@@ -203,6 +203,18 @@ fn_networking() {
 
     log_h3 "cat /etc/services"
     cat /etc/services || true
+
+    log_h3 "ls -lah /etc/wifi"
+    ls -lah /etc/wifi || true
+
+    log_h3 "cat /etc/wifi/wpa_supplicant.conf"
+    cat /etc/wifi/wpa_supplicant.conf || true
+
+    log_h3 "ls -lah /etc/wpa_supplicant"
+    ls -lah /etc/wpa_supplicant || true
+
+    log_h3 "cat /etc/wpa_supplicant/wpa_supplicant.conf"
+    cat /etc/wpa_supplicant/wpa_supplicant.conf || true
 }
 
 fn_env() {


### PR DESCRIPTION
Depending on the OS, this information can be in /etc/wifi or /etc/wpa_supplicant.