### PR TITLE
fix: re-add evtest and simplify launch.sh

### DIFF
--- a/.gitarchiveinclude
+++ b/.gitarchiveinclude
@@ -1,5 +1,4 @@
-bin/minui-btntest-tg5040
-bin/minui-btntest-rg35xxplus
+bin/evtest
 bin/sdl2imgshow
 bin/coreutils
 bin/coreutils.LICENSE

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,5 +2,6 @@
 .gitattributes export-ignore
 .gitarchiveinclude export-ignore
 .gitignore export-ignore
+Dockerfile.evtest export-ignore
 Dockerfile.sdl2imgshow export-ignore
 Makefile export-ignore

--- a/Dockerfile.evtest
+++ b/Dockerfile.evtest
@@ -1,0 +1,24 @@
+FROM golang:1.23.4-bullseye
+
+ARG EVTEST_VERSION=evtest-1.35
+ENV EVTEST_VERSION=$EVTEST_VERSION
+
+RUN git clone https://gitlab.freedesktop.org/libevdev/evtest.git/ /go/src/github.com/freedesktop/evtest && \
+    git -C /go/src/github.com/freedesktop/evtest checkout "tags/$EVTEST_VERSION"
+
+WORKDIR /go/src/github.com/freedesktop/evtest
+
+ENV GOOS=linux
+ENV GOARCH=arm64
+ENV CGO_ENABLED=1
+ENV CC=aarch64-linux-gnu-gcc
+
+RUN apt-get update && apt-get install -y autoconf
+RUN ./autogen.sh
+RUN ./configure --prefix=/usr  --host=aarch64-linux-gnu
+RUN make
+
+RUN apt-get update && apt-get install -y file
+
+RUN ls -lah /go/src/github.com/freedesktop/evtest
+RUN file /go/src/github.com/freedesktop/evtest/evtest

--- a/Makefile
+++ b/Makefile
@@ -3,21 +3,21 @@ BUILD_DATE := "$(shell date -u +%FT%TZ)"
 PAK_NAME := $(shell jq -r .label config.json)
 COREUTILS_VERSION := 0.0.28
 
-PLATFORMS := tg5040 rg35xxplus
-MINUI_BTNTEST_VERSION := 0.2.0
-
 clean:
-	rm -f bin/minui-btntest-* || true
+	rm -rf bin/evtest || true
 	rm -f bin/sdl2imgshow || true
 	rm -f bin/coreutils || true
 	rm -f bin/coreutils.LICENSE || true
 	rm -f res/fonts/BPreplayBold.otf || true
 
-build: $(foreach platform,$(PLATFORMS),bin/minui-btntest-$(platform)) bin/sdl2imgshow bin/coreutils res/fonts/BPreplayBold.otf
+build: bin/evtest bin/sdl2imgshow bin/coreutils res/fonts/BPreplayBold.otf
 
-bin/minui-btntest-%:
-	curl -f -o bin/minui-btntest-$* -sSL https://github.com/josegonzalez/minui-btntest/releases/download/$(MINUI_BTNTEST_VERSION)/minui-btntest-$*
-	chmod +x bin/minui-btntest-$*
+bin/evtest:
+	docker buildx build --platform linux/arm64 --load -f Dockerfile.evtest --progress plain -t app/evtest:$(TAG) .
+	docker container create --name extract app/evtest:$(TAG)
+	docker container cp extract:/go/src/github.com/freedesktop/evtest/evtest bin/evtest
+	docker container rm extract
+	chmod +x bin/evtest
 
 bin/sdl2imgshow:
 	docker buildx build --platform linux/arm64 --load -f Dockerfile.sdl2imgshow --progress plain -t app/sdl2imgshow:$(TAG) .


### PR DESCRIPTION
The launch.sh script doesn't need evtest, but the report script uses it.